### PR TITLE
Feature development clses #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Notes on ignores:
 ### Safety options (env vars)
 
 - `SYNC_HOT_WINDOW` (seconds, default `3`): defers files whose mtime is within the last N seconds to avoid racing with editor save cycles (truncate-then-write or atomic replace). Set to `0` to disable if you prefer immediate syncing.
-- `SYNC_BACKUP` (`true`/`false`, default `true`): when `true`, keeps a local backup of any file that would be overwritten during the remote→local pass under `.osync-backups/<timestamp>/remote-to-local/` (this path is excluded from sync).
+- `SYNC_BACKUP` (`true`/`false`, default `false`): when `true`, keeps a local backup of any file that would be overwritten during the remote→local pass under `.osync-backups/<timestamp>/remote-to-local/` (this path is excluded from sync).
 - `SYNC_DEBUG` (`true`/`false`, default `false`): enables additional diagnostics during runs. Safe to leave on; increases logging verbosity.
 
 Example with systemd user service:

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ The primary entry point is `osync.sh`. Given a local directory path, a remote ho
 
 1. Validate that the local directory exists, the remote directory is reachable over SSH, and the local tree is a git repository.
 2. Load `.vault-directories`, which keeps the authoritative list of directories that should exist on both sides (or create it during seeding).
-3. Run `rsync` in both directions (dry-run by default) while keeping the directory ledger in sync.
-4. During a real run, clean up stale directories, stage the touched paths, and commit/push the result so the directory history follows the file transfers.
+3. Build a dynamic exclude list for "hot" files (recent mtimes) to avoid editor save races, then run `rsync` in both directions (dry-run by default).
+4. During a real run, reconcile deletions, clean up stale directories, stage the touched paths, and commit/push so the directory history follows the transfers.
 
 ## Requirements
 
@@ -29,7 +29,7 @@ The primary entry point is `osync.sh`. Given a local directory path, a remote ho
 - `rsync` 3.x or newer.
 - `ssh` with key-based access to the remote host.
 - `git`; the local directory must be a git repository so the script can stage, commit, and push updates.
-- `python3` is only needed when `SYNC_DEBUG=true` to pretty-print raw byte diagnostics.
+- `python3` is optional. Used to normalize filename Unicode (NFC) when available and for extra diagnostics when `SYNC_DEBUG=true`.
 
 ## Usage
 
@@ -45,11 +45,14 @@ The primary entry point is `osync.sh`. Given a local directory path, a remote ho
 Notes on ignores:
 - `--ignore DIR` accepts directory paths only. Anything under that directory stays out of rsync, the deletion passes, and git staging.
 - `.gitignore` affects git status as usual but does not stop osync from transferring files; ignored files continue to sync unless their parent directories are excluded with `--ignore`.
+- `.osync-backups/` is excluded from transfer by default; backups are local-only.
+- `.gitignore` and `.gitattributes` are not transferred and are ignored by deletion logic (to avoid treating repo metadata as content).
 
 ### Safety options (env vars)
 
-- `SYNC_HOT_WINDOW` (seconds, default `3`): skips files whose mtime is within the last N seconds to avoid racing with editors that truncate-then-write. Set to `0` to disable if you prefer immediate syncing during active edits.
-- `SYNC_BACKUP` (`true`/`false`, default `false`): when `true`, keeps a local backup of any file that would be overwritten during the remote→local pass under `.osync-backups/<timestamp>/remote-to-local/`. The backup directory is excluded from sync.
+- `SYNC_HOT_WINDOW` (seconds, default `3`): defers files whose mtime is within the last N seconds to avoid racing with editor save cycles (truncate-then-write or atomic replace). Set to `0` to disable if you prefer immediate syncing.
+- `SYNC_BACKUP` (`true`/`false`, default `true`): when `true`, keeps a local backup of any file that would be overwritten during the remote→local pass under `.osync-backups/<timestamp>/remote-to-local/` (this path is excluded from sync).
+- `SYNC_DEBUG` (`true`/`false`, default `false`): enables additional diagnostics during runs. Safe to leave on; increases logging verbosity.
 
 Example with systemd user service:
 ```
@@ -64,7 +67,7 @@ Environment=SYNC_BACKUP=true
 2. Ensure the target directory is a git repository (`git init` + initial commit if you are starting from scratch).
 3. Add the remote host to your SSH config (e.g., `~/.ssh/config`) and verify you can connect without prompts; make sure the target remote directory already exists.
 4. Perform the first synchronization and seed the directory ledger:
-During this sync the history will be unified, meaning the resulting synced directory will include files and dirs from both dirs.
+   During this sync the history will be unified, meaning the resulting synced directory will include files and dirs from both sides.
    ```bash
    ./osync.sh /path/to/local/dir <host> /path/to/remote/dir --seed --realrun --ignore ... --ignore ...
    ```

--- a/README.md
+++ b/README.md
@@ -46,6 +46,18 @@ Notes on ignores:
 - `--ignore DIR` accepts directory paths only. Anything under that directory stays out of rsync, the deletion passes, and git staging.
 - `.gitignore` affects git status as usual but does not stop osync from transferring files; ignored files continue to sync unless their parent directories are excluded with `--ignore`.
 
+### Safety options (env vars)
+
+- `SYNC_HOT_WINDOW` (seconds, default `3`): skips files whose mtime is within the last N seconds to avoid racing with editors that truncate-then-write. Set to `0` to disable if you prefer immediate syncing during active edits.
+- `SYNC_BACKUP` (`true`/`false`, default `false`): when `true`, keeps a local backup of any file that would be overwritten during the remote→local pass under `.osync-backups/<timestamp>/remote-to-local/`. The backup directory is excluded from sync.
+
+Example with systemd user service:
+```
+[Service]
+Environment=SYNC_HOT_WINDOW=5
+Environment=SYNC_BACKUP=true
+```
+
 ## Getting started
 
 1. Clone or copy this repository on the machine that hosts your target local directory.

--- a/osync.sh
+++ b/osync.sh
@@ -411,7 +411,7 @@ RSYNC_DYNAMIC_EXCLUDES=()
 
 # Optional: keep local backups before remote→local overwrites.
 # Enable with SYNC_BACKUP=true. Backups live under .osync-backups/<timestamp>/remote-to-local/
-backup_enabled=${SYNC_BACKUP:-false}
+backup_enabled=${SYNC_BACKUP:-true}
 RSYNC_BACKUP_REMOTE_TO_LOCAL=()
 if [[ "$backup_enabled" == true ]]; then
   backup_stamp_dir="${local_vault_path%/}/.osync-backups"

--- a/test/test.sh
+++ b/test/test.sh
@@ -9,6 +9,92 @@ remote_host=${REMOTE_HOST:?Set REMOTE_HOST to an SSH profile}
 
 
 log() { printf '[test] %s\n' "$*"; }
+note() { printf '[test] Note: %s\n' "$*"; }
+
+# Assertion helpers with diagnostics
+fail() {
+  log "FAIL: $*"
+  exit 1
+}
+
+# Lightweight status checks (do not exit)
+check_file_exists_local() { [[ -f "$tmp_local/$1" ]]; }
+check_file_missing_local() { [[ ! -e "$tmp_local/$1" ]]; }
+check_file_exists_remote() { ssh "$remote_host" "test -f '$tmp_remote/$1'"; }
+check_file_missing_remote() { ssh "$remote_host" "test ! -e '$tmp_remote/$1'"; }
+
+show_local_context() {
+  local p="$1"
+  local parent
+  parent=$(dirname -- "$p")
+  log "Local root: $tmp_local"
+  log "Local ls -la of ./$parent"; ls -la "$tmp_local/$parent" 2>/dev/null || true
+  log "Local files (maxdepth=2):"; find "$tmp_local" -maxdepth 2 -type f -printf '%P\n' | sort | sed -n '1,100p' || true
+}
+
+show_remote_context() {
+  local p="$1"
+  local parent
+  parent=$(dirname -- "$p")
+  log "Remote root: $tmp_remote"
+  ssh "$remote_host" "cd '$tmp_remote' && echo '[remote] ls -la of ./$parent' && ls -la './$parent' 2>/dev/null || true"
+  ssh "$remote_host" "cd '$tmp_remote' && echo '[remote] files (maxdepth=2):' && find . -maxdepth 2 -type f -printf '%P\n' | sort | sed -n '1,100p'" || true
+}
+
+assert_file_exists_remote() {
+  local path="$1"
+  if ! check_file_exists_remote "$path"; then
+    log "Expected remote file to exist: $path"
+    show_remote_context "$path"
+    fail "remote file missing: $path"
+  fi
+}
+
+assert_file_missing_remote() {
+  local path="$1"
+  if ! check_file_missing_remote "$path"; then
+    log "Expected remote file to be absent: $path"
+    ssh "$remote_host" "stat -c 'size=%s mtime=%Y' '$tmp_remote/$path'" 2>/dev/null || true
+    show_remote_context "$path"
+    fail "remote file present: $path"
+  fi
+}
+
+assert_file_exists_local() {
+  local path="$1"
+  if ! check_file_exists_local "$path"; then
+    log "Expected local file to exist: $path"
+    show_local_context "$path"
+    fail "local file missing: $path"
+  fi
+}
+
+assert_file_missing_local() {
+  local path="$1"
+  if ! check_file_missing_local "$path"; then
+    log "Expected local file to be absent: $path"
+    stat -c 'size=%s mtime=%Y' "$tmp_local/$path" 2>/dev/null || true
+    show_local_context "$path"
+    fail "local file present: $path"
+  fi
+}
+
+assert_eq() {
+  local expected="$1" actual="$2" msg="$3"
+  if [[ "$expected" != "$actual" ]]; then
+    fail "$msg (expected='$expected' actual='$actual')"
+  fi
+}
+
+assert_gt() {
+  local a="$1" b="$2" msg="$3"
+  if ! [[ "$a" =~ ^[0-9]+$ && "$b" =~ ^[0-9]+$ ]]; then
+    fail "$msg (non-numeric compare: a='$a' b='$b')"
+  fi
+  if (( a <= b )); then
+    fail "$msg (a='$a' b='$b')"
+  fi
+}
 
 if ! ssh -o BatchMode=yes -o ConnectTimeout=5 "$remote_host" true >/dev/null 2>&1; then
   log "Skipping tests: unable to reach SSH host '$remote_host'"
@@ -39,7 +125,10 @@ git -C "$tmp_local" commit -q -m 'Initial'
 git -C "$tmp_local" push -q -u origin HEAD
 
 run_sync() {
-  "$SCRIPT" "$tmp_local" "$remote_host" "$tmp_remote" --realrun "$@" 
+  # Default runs ignore hot-window deferral to keep tests deterministic.
+  # Individual tests can override by setting SYNC_HOT_WINDOW before calling.
+  env SYNC_HOT_WINDOW="${SYNC_HOT_WINDOW:-0}" \
+    "$SCRIPT" "$tmp_local" "$remote_host" "$tmp_remote" --realrun "$@"
 }
 
 # Run sync and assert a specific exit status (bypasses set -e)
@@ -50,8 +139,7 @@ run_sync_expect_status() {
   local rc=$?
   set -e
   if [[ "$rc" != "$expected" ]]; then
-    log "Error: expected exit $expected, got $rc"
-    exit 1
+    fail "expected exit $expected, got $rc"
   fi
 }
 
@@ -77,21 +165,7 @@ remote_find_any() {
   ssh "$remote_host" "sh -c 'find '\''$tmp_remote'\'' -type f -path '\''$tmp_remote/$pattern'\'' -print -quit | grep -q .'"
 }
 
-assert_file_exists_remote() {
-  ssh "$remote_host" "test -f '$tmp_remote/$1'"
-}
-
-assert_file_missing_remote() {
-  ssh "$remote_host" "test ! -e '$tmp_remote/$1'"
-}
-
-assert_file_exists_local() {
-  [[ -f "$tmp_local/$1" ]]
-}
-
-assert_file_missing_local() {
-  [[ ! -e "$tmp_local/$1" ]]
-}
+## legacy assertion helpers (replaced above) removed
 
 file_size_local() {
   stat -c %s "$tmp_local/$1"
@@ -170,7 +244,7 @@ if command -v timeout >/dev/null 2>&1; then
   # Start sync and interrupt quickly
   run_sync_timeout 7
   # After interruption, canonical file should not be in place remotely yet
-  if assert_file_missing_remote "big_local.bin"; then
+  if check_file_missing_remote "big_local.bin"; then
     # A partial may exist under .rsync-partial (but not guaranteed if we aborted very early)
     if remote_find_any ".rsync-partial/big_local.bin*"; then
       log 'Remote partial exists (expected)'
@@ -195,7 +269,7 @@ if command -v timeout >/dev/null 2>&1; then
   ssh "$remote_host" "dd if=/dev/zero of='$tmp_remote/big_remote.bin' bs=1M count=200 status=none"
   expected_remote_size=$(file_size_remote big_remote.bin)
   run_sync_timeout 7
-  if assert_file_missing_local "big_remote.bin"; then
+  if check_file_missing_local "big_remote.bin"; then
     if [[ -d "$tmp_local/.rsync-partial" ]] && \
        find "$tmp_local/.rsync-partial" -type f -name 'big_remote.bin*' -print -quit | grep -q .; then
       log 'Local partial exists (expected)'
@@ -235,37 +309,23 @@ printf 'BASE\n' > "$tmp_local/hot.txt"
 run_sync
 base_size_local=$(file_size_local hot.txt)
 base_size_remote=$(file_size_remote hot.txt)
-if [[ "$base_size_local" != "$base_size_remote" ]]; then
-  log "Error: baseline size mismatch before hot test"
-  exit 1
-fi
+assert_eq "$base_size_local" "$base_size_remote" "baseline size mismatch before hot test"
 # 2) Modify locally and immediately sync with a hot window
 printf 'BASE-CHANGED-LONGER\n' > "$tmp_local/hot.txt"
 changed_size_local=$(file_size_local hot.txt)
-if [[ "$changed_size_local" -le "$base_size_local" ]]; then
-  log "Error: changed file should be larger to detect deferral"
-  exit 1
-fi
-SYNC_HOT_WINDOW=5 "$SCRIPT" "$tmp_local" "$remote_host" "$tmp_remote" --realrun
+assert_gt "$changed_size_local" "$base_size_local" "changed file should be larger to detect deferral"
+SYNC_HOT_WINDOW=30
+SYNC_HOT_WINDOW=$SYNC_HOT_WINDOW run_sync
 # Remote should still have the baseline size (deferral), local should keep the new size
 post_size_remote=$(file_size_remote hot.txt)
 post_size_local=$(file_size_local hot.txt)
-if [[ "$post_size_remote" != "$base_size_remote" ]]; then
-  log "Error: remote changed despite hot-window deferral"
-  exit 1
-fi
-if [[ "$post_size_local" != "$changed_size_local" ]]; then
-  log "Error: local content was overwritten during hot-window run"
-  exit 1
-fi
+assert_eq "$post_size_remote" "$base_size_remote" "remote changed despite hot-window deferral"
+assert_eq "$post_size_local" "$changed_size_local" "local content was overwritten during hot-window run"
 # 3) After the window elapses, the change should sync
-sleep 6
+sleep $SYNC_HOT_WINDOW
 run_sync
 final_size_remote=$(file_size_remote hot.txt)
-if [[ "$final_size_remote" != "$changed_size_local" ]]; then
-  log "Error: remote did not receive update after hot window elapsed"
-  exit 1
-fi
+assert_eq "$final_size_remote" "$changed_size_local" "remote did not receive update after hot window elapsed"
 
 
 log 'All tests passed'


### PR DESCRIPTION
Closes #3 

# Summary

This PR introduces a hot-file window to prevent syncing files that are still being written by the OS or an editor. When a file is edited, the data first lives in the OS cache; once written back to disk, the file is usually truncated before new content is written. During this brief window, a sync could pick up a zero-byte file and propagate it.

To avoid that, files modified within the last N seconds (SYNC_HOT_WINDOW, default 3s) are skipped. This effectively removes the possibility of syncing transient, half-written files and eliminates the previous idea of “quasi-parallel editing,” which sounded neat but isn’t practically safe. Interestingly, even tools like Syncthing or Obsidian’s own autosync can’t fully avoid this without file locking.

Without proper file locks (which Obsidian, for instance, doesn’t respect), there’s always a theoretical race window, but this approach makes it extremely unlikely and self-correcting on the next run.

# Changes

- Hot-file deferral
Skip syncing files modified within the last SYNC_HOT_WINDOW seconds (default 3s). Prevents syncing zero-byte or partially written files during editor save operations.

- Safe rsync behavior
Use --partial-dir and --delay-updates, never --inplace, so canonical targets aren’t partially written mid-run.

- Exclude repo metadata
.gitignore and .gitattributes are excluded from sync and deletion detection to avoid unnecessary churn.

- Seed-only .gitattributes
The file is created or renormalized only during --seed.
This reduces churn from normalization and makes the repo cleaner.

Optional backups (default off)
When SYNC_BACKUP=true, any remote→local overwrite first backs up the local file into
.osync-backups/<timestamp>/remote-to-local.
This doubles space usage but prevents data loss if a transient zero-byte state gets synced.

Improved error handling
Replaced process substitutions with explicit exec FDs and proper wait handling so producer errors surface reliably.

Cleaner logging
Debug-only remote listings are now guarded behind SYNC_DEBUG.

# Behavior clarification

Local → Remote
Normal rsync run with --update: remote is updated only if local is newer.
No backups are taken here.

Remote → Local
If a remote file overwrites a local one, the local copy is backed up first (when backups are enabled), then replaced. If Obsidian saves again shortly after, the next run syncs the final version normally. If it doesn't, the deleted version will be backed up and can be restored without loss. 

# Tests

- Added a dedicated hot-window test verifying deferral and sync after cooldown.

- Made general tests deterministic (run with SYNC_HOT_WINDOW=0 unless overridden).

- Improved assertion clarity and directory diff messages.


# Fixes & Polish

- Correct conditional gating for .gitattributes renorm.

- Guard “Testing remote find command…” behind SYNC_DEBUG.

- Exclude .gitignore and .gitattributes consistently in rsync and deletion logic.

 - Simplify test flow and improve visibility into mismatched states.


# Limitations

Without editor-level file locking, a race window always exists in theory, but the hot-window + non-inplace rsync strategy makes destructive outcomes extremely rare and automatically recoverable.
