### PR TITLE
Clarify project affiliation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 `osync` is a small personal project that keeps two directories in sync across machines. It wraps `rsync` and `git` so that your files (and the history around them) stay aligned with as little ceremony as possible.
 
+⚠️ Note: This project is not affiliated with or related to any other project named “osync.”
+If you were looking for [deajans osync](https://github.com/deajan/osync), this isn’t it.
+
 ## Why osync?
 
 - Works over plain SSH, so any reachable host can participate without extra services.


### PR DESCRIPTION
Add a note clarifying project affiliation and distinction.

There are plenty of different projects called osync. There happens to be one that is more popular that is also known as osync and uses rsync, although the approach is different i.e. they don't use git and afaik it is only a syncing solution. Nevertheless I want to reduce some friction and clarify affiliation.
Closes #6 